### PR TITLE
delete link to non-existent script

### DIFF
--- a/src/html/layout.html
+++ b/src/html/layout.html
@@ -3,7 +3,6 @@
     <head>
         <title>Kaiwa</title>
         <link rel="stylesheet" href="../stylus/client">
-        <script src="/js/1-vendor.js"></script>
         <link rel="shortcut icon" type="image/png" href="/images/kaiwa.png">
     </head>
     <body>


### PR DESCRIPTION
Since webpack.config.js entry section have only 'js/app' chunk name, webpack doesn't bundle 1-vendor.js.