### PR TITLE
No more Kaiwa on chat.jabber.ru

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,8 +2,6 @@ Kaiwa [![Build Status](https://travis-ci.org/ForNeVeR/kaiwa.svg?branch=develop)]
 =====
 Kaiwa is an open source web client for XMPP.  
 
-Our production server is http://chat.jabber.ru
-
 Alpha version is always hosted on http://kaiwa.fornever.me (**warning: there may
 be highly unstable code there, you're recommended to use test accounts with this
 server**).


### PR DESCRIPTION
I did remove reference to chat.jabber.ru from README, please, also remove it from project title.